### PR TITLE
Allow testing of ants

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -43,6 +43,7 @@ import { RestrictedValuesDirective } from './directives/restricted-values.direct
 import { ThemeSelectorComponent } from './components/theme-selector/theme-selector.component';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatRadioModule } from '@angular/material/radio';
+import { TestAntDialogComponent } from './components/test-ant-dialog/test-ant-dialog.component';
 
 @NgModule({
   declarations: [
@@ -59,6 +60,7 @@ import { MatRadioModule } from '@angular/material/radio';
     IconSizeDirective,
     RestrictedValuesDirective,
     ThemeSelectorComponent,
+    TestAntDialogComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/ant-grid/ant-grid.component.ts
+++ b/src/app/components/ant-grid/ant-grid.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, ViewChild, ElementRef, AfterViewInit, OnChanges, SimpleChanges, ChangeDetectorRef } from '@angular/core';
 import { Ant, Food } from 'src/app/models/board';
+import { ThemeService } from '../../services/theme.service';
 
 @Component({
   selector: 'cci-ant-grid',
@@ -21,7 +22,7 @@ export class AntGridComponent implements AfterViewInit, OnChanges {
   canvasHeight = 0;
   cellSize = 6;
 
-  constructor(private cdr: ChangeDetectorRef) { }
+  constructor(private cdr: ChangeDetectorRef, private theme: ThemeService) { }
 
   ngAfterViewInit(): void {
     this.context = this.canvas.nativeElement.getContext('2d');
@@ -89,15 +90,12 @@ export class AntGridComponent implements AfterViewInit, OnChanges {
 
       this.context.globalAlpha = 1;
 
-      this.context.strokeStyle = '#a5a5a5';
-      this.context.rect(this.cellSize, this.cellSize, this.canvasWidth - this.cellSize * 2, this.canvasHeight - this.cellSize * 2);
-      this.context.stroke();
-
       for (const ant of this.food) {
         const centerX = ant.column * this.cellSize + (this.cellSize / 2);
         const centerY = ant.row * this.cellSize + (this.cellSize / 2);
         const radius = this.cellSize / 2 - 1;
-        this.drawCircle(centerX, centerY, radius, 'brown', 'black', 1);
+        const stroke = this.theme.isDarkTheme() ? 'black' : 'darkgray';
+        this.drawCircle(centerX, centerY, radius, 'brown', stroke, 0);
       }
 
       for (let i = 0; i < this.ants.length; i++) {
@@ -143,7 +141,7 @@ export class AntGridComponent implements AfterViewInit, OnChanges {
     if (ant.antName === this.leader?.antName) {
       return 'gold';
     }
-    return 'white';
+    return this.theme.isDarkTheme() ? 'white' : 'black';
   }
 
   private drawCircle(centerX: number, centerY: number, radius: number, fillColor: string, strokeColor: string, lineWidth: number): void {

--- a/src/app/components/ant-grid/ant-grid.component.ts
+++ b/src/app/components/ant-grid/ant-grid.component.ts
@@ -10,6 +10,7 @@ export class AntGridComponent implements AfterViewInit, OnChanges {
 
   @ViewChild('canvas') canvas: ElementRef<HTMLCanvasElement>;
   public context: CanvasRenderingContext2D;
+  private leader?: Ant;
 
   @Input() grid: number[][] = [];
   @Input() ants: Ant[] = [];
@@ -24,14 +25,30 @@ export class AntGridComponent implements AfterViewInit, OnChanges {
 
   ngAfterViewInit(): void {
     this.context = this.canvas.nativeElement.getContext('2d');
-    this.canvasHeight = this.grid.length * this.cellSize;
-    this.canvasWidth = this.grid[0].length * this.cellSize;
+    this.canvasHeight = this.grid.length * this.cellSize + this.cellSize * 2;
+    this.canvasWidth = this.grid[0].length * this.cellSize + this.cellSize * 2;
     this.cdr.detectChanges();
-    this.draw();
+    window.requestAnimationFrame(() => this.draw());
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    this.draw();
+    if (changes.ants) {
+      if (this.ants && this.ants.length > 1) {
+        const leader = this.ants.sort((a, b) => {
+          if (a.score > b.score) {
+            return 1;
+          } else if (a.score < b.score) {
+            return -1;
+          } else {
+            return 0;
+          }
+        })[this.ants.length - 1];
+        if (leader && leader.score) {
+          this.leader = leader;
+        }
+      }
+      window.requestAnimationFrame(() => this.draw(changes.ants.previousValue));
+    }
   }
 
   private getColor(value: number): string {
@@ -55,8 +72,7 @@ export class AntGridComponent implements AfterViewInit, OnChanges {
     }
   }
 
-  draw(): void {
-    requestAnimationFrame(() => this.draw);
+  draw(previousAnts?: Ant[], step?: number): void {
     if (this.context) {
       this.context.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
       this.context.globalAlpha = 0.5;
@@ -66,12 +82,16 @@ export class AntGridComponent implements AfterViewInit, OnChanges {
           const value = this.grid[i][j];
           if (value > 1) {
             this.context.fillStyle = this.getColor(value);
-            this.context.fillRect(j * this.cellSize, i * this.cellSize, this.cellSize, this.cellSize);
+            this.context.fillRect(j * this.cellSize + this.cellSize, i * this.cellSize + this.cellSize, this.cellSize, this.cellSize);
           }
         }
       }
 
       this.context.globalAlpha = 1;
+
+      this.context.strokeStyle = '#a5a5a5';
+      this.context.rect(this.cellSize, this.cellSize, this.canvasWidth - this.cellSize * 2, this.canvasHeight - this.cellSize * 2);
+      this.context.stroke();
 
       for (const ant of this.food) {
         const centerX = ant.column * this.cellSize + (this.cellSize / 2);
@@ -80,18 +100,55 @@ export class AntGridComponent implements AfterViewInit, OnChanges {
         this.drawCircle(centerX, centerY, radius, 'brown', 'black', 1);
       }
 
-      for (const ant of this.ants) {
-        const centerX = ant.column * this.cellSize + (this.cellSize / 2);
-        const centerY = ant.row * this.cellSize + (this.cellSize / 2);
-        const radius = this.cellSize / 2 + 2;
-        this.drawCircle(centerX, centerY, radius, ant.color, 'white', 2);
+      for (let i = 0; i < this.ants.length; i++) {
+        if (previousAnts) {
+          if (!step) {
+            step = 0;
+          }
+          const previousAnt = previousAnts[i];
+          const centerX = this.ants[i].column * this.cellSize + (this.cellSize / 2);
+          const centerY = this.ants[i].row * this.cellSize + (this.cellSize / 2);
+          const prevCenterX = previousAnt.column * this.cellSize + (this.cellSize / 2);
+          const prevCenterY = previousAnt.row * this.cellSize + (this.cellSize / 2);
+          const dx = prevCenterX + (centerX - prevCenterX) * step;
+          const dy = prevCenterY + (centerY - prevCenterY) * step;
+          const radius = this.cellSize / 2 + 2;
+          if (Math.abs(centerX - prevCenterX) > this.cellSize ||
+              Math.abs(centerY - prevCenterY) > this.cellSize) {
+            this.drawCircle(centerX, centerY, radius, this.ants[i].color, this.getAntStrokeColor(this.ants[i]), 2);
+          } else {
+            this.drawCircle(dx, dy, radius, this.ants[i].color, this.getAntStrokeColor(this.ants[i]), 2);
+          }
+        } else {
+          const centerX = this.ants[i].column * this.cellSize + (this.cellSize / 2);
+          const centerY = this.ants[i].row * this.cellSize + (this.cellSize / 2);
+          const radius = this.cellSize / 2 + 2;
+          const color = this.ants[i].error ? 'red' :
+          this.drawCircle(centerX, centerY, radius, this.ants[i].color, this.getAntStrokeColor(this.ants[i]), 2);
+        }
+      }
+
+      step += 0.1;
+      if (step <= 1) {
+        window.requestAnimationFrame(() => this.draw(previousAnts, step));
       }
     }
   }
 
+  private getAntStrokeColor(ant: Ant) {
+    if (ant.error) {
+      return 'red';
+    }
+
+    if (ant.antName === this.leader?.antName) {
+      return 'gold';
+    }
+    return 'white';
+  }
+
   private drawCircle(centerX: number, centerY: number, radius: number, fillColor: string, strokeColor: string, lineWidth: number): void {
     this.context.beginPath();
-    this.context.arc(centerX, centerY, radius, 0, 2 * Math.PI, false);
+    this.context.arc(centerX + this.cellSize, centerY + this.cellSize, radius, 0, 2 * Math.PI, false);
     this.context.fillStyle = fillColor;
     this.context.fill();
     this.context.lineWidth = lineWidth;

--- a/src/app/components/edit-ant/edit-ant.component.html
+++ b/src/app/components/edit-ant/edit-ant.component.html
@@ -2,6 +2,9 @@
   <mat-toolbar class="edit-ant__toolbar">
     <div fxFlex></div>
     <span>{{ antName$ | async }}</span>
+    <button mat-icon-button (click)="testAnt()" matTooltip="Test this ant">
+      <mat-icon>play_circle_outline</mat-icon>
+    </button>
     <div fxFlex></div>
     <button mat-icon-button (click)="submit()" [disabled]="!dirty" matTooltip="Save this ant">
       <mat-icon>save</mat-icon>

--- a/src/app/components/edit-ant/edit-ant.component.ts
+++ b/src/app/components/edit-ant/edit-ant.component.ts
@@ -8,6 +8,8 @@ import { map, switchMap } from 'rxjs/operators';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ConfirmDeleteDialogComponent } from '../confirm-delete-dialog/confirm-delete-dialog.component';
 import { ThemeService } from '../../services/theme.service';
+import { TestAntDialogComponent } from '../test-ant-dialog/test-ant-dialog.component';
+import { GameService } from '../../services/game.service';
 
 @Component({
   selector: 'cci-edit-ant',
@@ -40,6 +42,7 @@ export class EditAntComponent implements OnInit {
     private submissionService: SubmissionService,
     private route: ActivatedRoute,
     private router: Router,
+    private gameService: GameService,
     private dialog: MatDialog,
     private themeService: ThemeService,
     private snackBar: MatSnackBar,
@@ -81,6 +84,16 @@ export class EditAntComponent implements OnInit {
     this.submissionService.submitAnt$(this.route.snapshot.params.antName, this.codeModel.value).subscribe(result => {
       this.snackBar.open('Ant Saved Successfully', undefined, { duration: 2000 });
       this.dirty = false;
+    });
+  }
+
+  testAnt(): void {
+    this.dialog.open(TestAntDialogComponent, {
+      data: {
+        code: this.codeModel.value,
+      },
+      minWidth: '300px',
+      minHeight: '300px',
     });
   }
 

--- a/src/app/components/edit-ant/edit-ant.component.ts
+++ b/src/app/components/edit-ant/edit-ant.component.ts
@@ -90,6 +90,7 @@ export class EditAntComponent implements OnInit {
   testAnt(): void {
     this.dialog.open(TestAntDialogComponent, {
       data: {
+        antName: this.route.snapshot.params.antName,
         code: this.codeModel.value,
       },
       minWidth: '300px',

--- a/src/app/components/edit-ant/edit-ant.component.ts
+++ b/src/app/components/edit-ant/edit-ant.component.ts
@@ -66,7 +66,7 @@ export class EditAntComponent implements OnInit {
   }
 
   private refreshTheme(): void {
-    if (this.themeService.currentThemeClass.indexOf('dark') >= 0) {
+    if (this.themeService.isDarkTheme()) {
       this.theme = 'vs-dark';
     } else {
       this.theme = 'vs';

--- a/src/app/components/leaderboard/leaderboard.component.html
+++ b/src/app/components/leaderboard/leaderboard.component.html
@@ -16,6 +16,16 @@
       <td mat-cell *matCellDef="let ant"> {{ ant.score | number }} </td>
     </ng-container>
 
+    <ng-container matColumnDef="errors">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>Errors</th>
+      <td mat-cell *matCellDef="let ant">
+        <div *ngIf="ant.error" class="mat-error" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
+          <mat-icon color="warn" [matTooltip]="ant.error">error</mat-icon>
+          <div>{{ ant.error }}</div>
+        </div>
+      </td>
+    </ng-container>
+
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
     <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
   </table>

--- a/src/app/components/leaderboard/leaderboard.component.ts
+++ b/src/app/components/leaderboard/leaderboard.component.ts
@@ -12,7 +12,7 @@ export class LeaderboardComponent implements OnInit, OnChanges {
 
   @Input() ants: Ant[] = [];
   @ViewChild(MatSort, {static: true}) sort: MatSort;
-  displayedColumns: string[] = ['name', 'score'];
+  displayedColumns: string[] = ['name', 'score', 'errors'];
   dataSource: MatTableDataSource<Ant>;
 
   constructor() { }

--- a/src/app/components/test-ant-dialog/test-ant-dialog.component.html
+++ b/src/app/components/test-ant-dialog/test-ant-dialog.component.html
@@ -1,0 +1,18 @@
+<mat-dialog-content>
+  <div *ngIf="board$ | async as board else loadingTemplate" fxLayout="column" fxLayoutGap="32px" fxLayoutAlign="start center">
+    <cci-ant-grid
+      [ants]="board.ants"
+      [food]="board.food"
+      [elapsedTicks]="board.elapsedTicks"
+      [grid]="board.grid">
+    </cci-ant-grid>
+    <cci-leaderboard [ants]="board.ants"></cci-leaderboard>
+  </div>
+</mat-dialog-content>
+
+<ng-template #loadingTemplate>
+  <div class="game" fxLayoutAlign="center center" [style.height]="'300px'"
+  [style.width]="'300px'">
+    <mat-spinner></mat-spinner>
+  </div>
+</ng-template>

--- a/src/app/components/test-ant-dialog/test-ant-dialog.component.ts
+++ b/src/app/components/test-ant-dialog/test-ant-dialog.component.ts
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs';
 import { BoardResponse } from 'src/app/models/board';
 
 export interface TestAntDialogData {
+  antName: string;
   code: string;
 }
 
@@ -23,7 +24,7 @@ export class TestAntDialogComponent {
     @Inject(MAT_DIALOG_DATA) data: TestAntDialogData,
     dialogRef: MatDialogRef<TestAntDialogComponent>,
     gameService: GameService) {
-    this.board$ = gameService.createTestGame$(data.code).pipe(switchMap(gameId => {
+    this.board$ = gameService.createTestGame$(data.antName, data.code).pipe(switchMap(gameId => {
       gameId = gameId;
       return gameService.getBoard$(gameId);
     }));

--- a/src/app/components/test-ant-dialog/test-ant-dialog.component.ts
+++ b/src/app/components/test-ant-dialog/test-ant-dialog.component.ts
@@ -31,7 +31,6 @@ export class TestAntDialogComponent {
 
     // Remove this game when closed / no longer needed
     dialogRef.afterClosed().subscribe(() => {
-      console.log('wanting to delete' , this.gameId);
       if (this.gameId) {
         gameService.deleteGame$(this.gameId).subscribe();
       }

--- a/src/app/components/test-ant-dialog/test-ant-dialog.component.ts
+++ b/src/app/components/test-ant-dialog/test-ant-dialog.component.ts
@@ -1,0 +1,39 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { GameService } from '../../services/game.service';
+import { switchMap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { BoardResponse } from 'src/app/models/board';
+
+export interface TestAntDialogData {
+  code: string;
+}
+
+@Component({
+  selector: 'cci-test-ant-dialog',
+  templateUrl: './test-ant-dialog.component.html',
+  styleUrls: ['./test-ant-dialog.component.scss']
+})
+export class TestAntDialogComponent {
+
+  readonly board$: Observable<BoardResponse>;
+  private gameId = '';
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) data: TestAntDialogData,
+    dialogRef: MatDialogRef<TestAntDialogComponent>,
+    gameService: GameService) {
+    this.board$ = gameService.createTestGame$(data.code).pipe(switchMap(gameId => {
+      gameId = gameId;
+      return gameService.getBoard$(gameId);
+    }));
+
+    // Remove this game when closed / no longer needed
+    dialogRef.afterClosed().subscribe(() => {
+      console.log('wanting to delete' , this.gameId);
+      if (this.gameId) {
+        gameService.deleteGame$(this.gameId).subscribe();
+      }
+    });
+  }
+}

--- a/src/app/models/board.ts
+++ b/src/app/models/board.ts
@@ -4,6 +4,7 @@ export interface Ant {
   row: number;
   score: number;
   color: string;
+  error: string;
 }
 
 export interface Food {

--- a/src/app/services/game.service.ts
+++ b/src/app/services/game.service.ts
@@ -45,8 +45,8 @@ export class GameService {
     return this.httpClient.post(url, {}, { responseType: 'text' });
   }
 
-  createTestGame$(code: string): Observable<string> {
+  createTestGame$(antName: string, code: string): Observable<string> {
     const url = `${environment.backendApi}/test`;
-    return this.httpClient.post(url, { code }, { responseType: 'text' });
+    return this.httpClient.post(url, { antName, code }, { responseType: 'text' });
   }
 }

--- a/src/app/services/game.service.ts
+++ b/src/app/services/game.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
-import { Observable, interval, of, timer, Subject } from 'rxjs';
+import { Observable, interval, Subject } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { BoardResponse } from '../models/board';
-import { switchMap, takeUntil, takeWhile, tap } from 'rxjs/operators';
+import { switchMap, takeUntil, tap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { ConfigResponse } from '../models/config';
 
@@ -35,8 +35,18 @@ export class GameService {
       }));
   }
 
+  deleteGame$(gameId: string): Observable<any> {
+    const url = `${environment.backendApi}/game/${gameId}`;
+    return this.httpClient.delete(url);
+  }
+
   createGame$(): Observable<string> {
     const url = `${environment.backendApi}/game`;
     return this.httpClient.post(url, {}, { responseType: 'text' });
+  }
+
+  createTestGame$(code: string): Observable<string> {
+    const url = `${environment.backendApi}/test`;
+    return this.httpClient.post(url, { code }, { responseType: 'text' });
   }
 }

--- a/src/app/services/theme.service.ts
+++ b/src/app/services/theme.service.ts
@@ -52,6 +52,9 @@ export class ThemeService {
     ]);
   }
 
+  isDarkTheme(): boolean {
+    return this.currentThemeClass.indexOf('dark') >= 0;
+  }
 
   /**
    * Set the theme of the application

--- a/src/app/views/edit-ants/edit-ants.component.ts
+++ b/src/app/views/edit-ants/edit-ants.component.ts
@@ -6,6 +6,8 @@ import { MatDialog } from '@angular/material/dialog';
 import { RulesDialogComponent } from 'src/app/components/rules-dialog/rules-dialog.component';
 import { CreateAntDialogComponent } from 'src/app/components/create-ant-dialog/create-ant-dialog.component';
 import { Router, ActivatedRoute } from '@angular/router';
+import { HttpClient } from '@angular/common/http';
+import { switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'cci-edit-ants',
@@ -20,6 +22,7 @@ export class EditAntsComponent implements OnInit {
     private submissionService: SubmissionService,
     public route: ActivatedRoute,
     private router: Router,
+    private http: HttpClient,
     private dialog: MatDialog) {
     this.ants$ = submissionService.ants$;
   }
@@ -35,7 +38,9 @@ export class EditAntsComponent implements OnInit {
     const dialogRef = this.dialog.open(CreateAntDialogComponent);
     dialogRef.afterClosed().subscribe(antName => {
       if (antName) {
-        this.submissionService.submitAnt$(antName, `// Write ${antName} here`).subscribe(() => {
+        this.http.get('assets/default-ant.js', { responseType: 'text' }).pipe(switchMap(code => {
+          return this.submissionService.submitAnt$(antName, code);
+        })).subscribe(() => {
           this.router.navigate(['/edit-ants', antName]);
         });
       }

--- a/src/assets/default-ant.js
+++ b/src/assets/default-ant.js
@@ -1,0 +1,28 @@
+/*
+Example outputs:
+    {cell:0}: move to cell 0
+    {cell:4}: move to cell 4 (that is, do nothing, as 4 is the central cell)
+    {cell:4, color:8}: set own cell to color 8
+    {cell:6, color:1}: set cell 6 to color 1
+    {cell:6, color:0}: equivalent to just `{cell:6}` - move rather than set color
+
+Invalid Outputs:
+    {cell: 9}: cell must be between 0-8.
+    {cell0, color:9}: color must be from 1-8.
+
+antView contains the cells around the ant.  Each item in the array contains:
+    color: a number from 1-8
+    food: 1 if present, 0 if not.
+
+Cells are ordered in the following way:
+        0 1 2
+        3 4 5
+        6 7 8
+
+Note: Your orientation will be randomized
+*/
+var antView = view;
+
+return {
+    cell: 1
+};


### PR DESCRIPTION
k finally, we have testing of ants:
 - New button on the edit ant screen to allow the user to test the ant
 - Calls the new 'test' endpoint (runs a game with 1 ant)
 - When dialog is closed, it calls the DELETE game endpoint so games aren't left around
 - Added new 'Errors' column to the leaderboard so we can see errors / shows in test too:

![image](https://user-images.githubusercontent.com/22795574/83358385-1c3a3580-a341-11ea-9353-239b8dbeb531.png)
