### PR TITLE
Fix for test sizing issue in chrome

### DIFF
--- a/src/app/components/ant-grid/ant-grid.component.scss
+++ b/src/app/components/ant-grid/ant-grid.component.scss
@@ -1,3 +1,7 @@
 .ant-grid__ticks {
   text-align: center;
 }
+
+canvas {
+  display: block;
+}

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -26,7 +26,7 @@ export class LoginComponent implements OnInit, AfterViewInit {
   login(): void {
     this.auth.login(this.username);
     if (this.route.snapshot.queryParams.returnUrl) {
-      this.router.navigate(this.route.snapshot.queryParams.returnUrl);
+      this.router.navigate([this.route.snapshot.queryParams.returnUrl]);
     } else {
       this.router.navigate(['/home']);
     }

--- a/src/app/guards/authentication.guard.ts
+++ b/src/app/guards/authentication.guard.ts
@@ -14,7 +14,7 @@ export class AuthenticationGuard implements CanActivate {
     next: ActivatedRouteSnapshot,
     state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
     if (!this.auth.username) {
-      this.router.navigate(['/login'], { queryParams: { returnUrl: next.url }});
+      this.router.navigate(['/login'], { queryParams: { returnUrl: state.url }});
     }
     return !!this.auth.username;
   }


### PR DESCRIPTION
Apparently newer versions of chrome have issues with the sizing of the test dialog.  To fix this I've set the display to 'block' for the canvas element.  Seems to work just fine

Also fixed an issue where the 'returnUrl' was not being properly set when the user was not logged in